### PR TITLE
Add Blackjack CLI using Deck of Cards API

### DIFF
--- a/blackjack.py
+++ b/blackjack.py
@@ -1,22 +1,149 @@
-# blackjack.py
-"""
-Minimal starting point for a Blackjack (21) CLI using the Deck of Cards API.
-This file is intentionally simple so Codex can expand it.
-"""
+from __future__ import annotations
 
+from dataclasses import dataclass, field
 import argparse
+from typing import List, Tuple
+
+from deck_api import DeckClient, Card
 
 
-def main():
+@dataclass
+class Hand:
+    cards: List[Card] = field(default_factory=list)
+
+    def add(self, *cs: Card) -> None:
+        self.cards.extend(cs)
+
+    def as_codes(self) -> str:
+        return ", ".join(c.code for c in self.cards)
+
+
+@dataclass
+class Player:
+    name: str
+    bankroll: int
+    bet: int
+
+
+def hand_value(cards: List[Card]) -> Tuple[int, bool]:
+    total = 0
+    aces = 0
+    for c in cards:
+        v = c.value
+        if v in {"JACK", "QUEEN", "KING"}:
+            total += 10
+        elif v == "ACE":
+            total += 11
+            aces += 1
+        else:
+            total += int(v)
+    while total > 21 and aces:
+        total -= 10
+        aces -= 1
+    is_soft = aces > 0 and total < 21
+    return total, is_soft
+
+
+def should_dealer_draw(cards: List[Card]) -> bool:
+    total, is_soft = hand_value(cards)
+    if total < 17:
+        return True
+    if total == 17 and is_soft:
+        return False
+    return False
+
+
+def prompt_hit_or_stand() -> str:
+    while True:
+        choice = input("Hit or stand? [h/s]: ").strip().lower()
+        if choice in {"h", "hit"}:
+            return "hit"
+        if choice in {"s", "stand"}:
+            return "stand"
+
+
+def play_round(client: DeckClient, player: Player, stats: dict) -> None:
+    if client.remaining < 0.25 * client.initial_remaining:
+        client.reshuffle_remaining()
+
+    player_hand = Hand()
+    dealer_hand = Hand()
+    player_hand.add(*client.draw(2))
+    dealer_hand.add(*client.draw(2))
+
+    p_total, _ = hand_value(player_hand.cards)
+    print(f"Player: {player_hand.as_codes()} ({p_total})")
+    print(f"Dealer: {dealer_hand.cards[0].code}, [hidden]")
+
+    while True:
+        decision = prompt_hit_or_stand()
+        if decision == "hit":
+            player_hand.add(*client.draw(1))
+            p_total, _ = hand_value(player_hand.cards)
+            print(f"Player: {player_hand.as_codes()} ({p_total})")
+            if p_total > 21:
+                print("Bust! You lose.")
+                player.bankroll -= player.bet
+                stats["lost"] += 1
+                stats["played"] += 1
+                return
+        else:
+            break
+
+    d_total, _ = hand_value(dealer_hand.cards)
+    print(f"Dealer: {dealer_hand.as_codes()} ({d_total})")
+    while should_dealer_draw(dealer_hand.cards):
+        dealer_hand.add(*client.draw(1))
+        d_total, _ = hand_value(dealer_hand.cards)
+        print(f"Dealer: {dealer_hand.as_codes()} ({d_total})")
+
+    p_total, _ = hand_value(player_hand.cards)
+    if d_total > 21:
+        result = "Win"
+        player.bankroll += player.bet
+        stats["won"] += 1
+    elif p_total > d_total:
+        result = "Win"
+        player.bankroll += player.bet
+        stats["won"] += 1
+    elif p_total < d_total:
+        result = "Lose"
+        player.bankroll -= player.bet
+        stats["lost"] += 1
+    else:
+        result = "Push"
+        stats["push"] += 1
+    stats["played"] += 1
+    print(f"{result}. Bankroll: {player.bankroll}")
+
+
+def main() -> None:
     parser = argparse.ArgumentParser(description="Play Blackjack (21) with Deck of Cards API")
     parser.add_argument("--decks", type=int, default=6, help="Number of decks (default 6)")
     parser.add_argument("--bet", type=int, default=10, help="Fixed bet per round")
     parser.add_argument("--bankroll", type=int, default=100, help="Starting bankroll")
     args = parser.parse_args()
 
-    print("Blackjack starting...")
-    print(f"Decks: {args.decks}, Bet: {args.bet}, Bankroll: {args.bankroll}")
-    # TODO: integrate DeckClient, deal cards, implement game loop
+    try:
+        client = DeckClient(decks=args.decks)
+    except RuntimeError as exc:
+        print(exc)
+        raise SystemExit(1)
+
+    player = Player("You", bankroll=args.bankroll, bet=args.bet)
+    stats = {"played": 0, "won": 0, "lost": 0, "push": 0}
+
+    while True:
+        try:
+            play_round(client, player, stats)
+        except RuntimeError as exc:
+            print(exc)
+            raise SystemExit(1)
+        cont = input("Continue? (y/n): ").strip().lower()
+        if cont != "y":
+            break
+
+    print(f"Played: {stats['played']} | Won: {stats['won']} | Lost: {stats['lost']} | Push: {stats['push']} | Final bankroll: {player.bankroll}")
 
 
 if __name__ == "__main__":

--- a/deck_api.py
+++ b/deck_api.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import time
+import typing as t
+
+import requests
+
+
+@dataclass
+class Card:
+    code: str
+    value: str
+    suit: str
+    image: str
+
+
+class DeckClient:
+    def __init__(self, decks: int = 6, session: t.Optional[requests.Session] = None) -> None:
+        self.session = session or requests.Session()
+        url = f"https://www.deckofcardsapi.com/api/deck/new/shuffle/?deck_count={decks}"
+        resp = self._request("GET", url)
+        data = resp.json()
+        deck_id = data.get("deck_id")
+        remaining = data.get("remaining")
+        if not deck_id or remaining is None:
+            raise RuntimeError("Invalid response from Deck API when creating deck")
+        self.deck_id = str(deck_id)
+        self.initial_remaining = 52 * decks
+        self._remaining = int(remaining)
+
+    @property
+    def remaining(self) -> int:
+        return self._remaining
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        retries: int = 3,
+        timeout: float = 10.0,
+        **kwargs: t.Any,
+    ) -> requests.Response:
+        backoff = 0.5
+        last_exc: t.Optional[Exception] = None
+        for attempt in range(retries):
+            try:
+                resp = self.session.request(method, url, timeout=timeout, **kwargs)
+                if resp.status_code >= 400:
+                    snippet = resp.text[:100]
+                    raise RuntimeError(f"Deck API error {resp.status_code}: {snippet}")
+                return resp
+            except requests.RequestException as exc:  # network error
+                last_exc = exc
+                if attempt == retries - 1:
+                    break
+                time.sleep(backoff)
+                backoff *= 2
+        raise RuntimeError(f"Network error contacting Deck API: {last_exc}")
+
+    def draw(self, n: int = 1) -> list[Card]:
+        url = f"https://www.deckofcardsapi.com/api/deck/{self.deck_id}/draw/?count={n}"
+        resp = self._request("GET", url)
+        data = resp.json()
+        cards = data.get("cards")
+        remaining = data.get("remaining")
+        if cards is None or remaining is None:
+            raise RuntimeError("Invalid response from Deck API when drawing cards")
+        self._remaining = int(remaining)
+        return [Card(code=c["code"], value=c["value"], suit=c["suit"], image=c["image"]) for c in cards]
+
+    def reshuffle_remaining(self) -> None:
+        url = f"https://www.deckofcardsapi.com/api/deck/{self.deck_id}/shuffle/?remaining=true"
+        resp = self._request("GET", url)
+        data = resp.json()
+        remaining = data.get("remaining")
+        if remaining is None:
+            raise RuntimeError("Invalid response from Deck API when reshuffling")
+        self._remaining = int(remaining)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+addopts = "-q"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31.0
+pytest>=7.0.0

--- a/tests/test_blackjack.py
+++ b/tests/test_blackjack.py
@@ -1,0 +1,58 @@
+import blackjack
+from blackjack import hand_value, Player
+from deck_api import Card, DeckClient
+
+
+def _card(code: str, value: str) -> Card:
+    return Card(code=code, value=value, suit="TEST", image="")
+
+
+def test_hand_value_cases():
+    total, soft = hand_value([_card("AH", "ACE"), _card("6D", "6")])
+    assert total == 17 and soft
+
+    total, soft = hand_value([_card("AH", "ACE"), _card("AD", "ACE"), _card("9C", "9")])
+    assert total == 21 and not soft
+
+    total, soft = hand_value([
+        _card("AH", "ACE"),
+        _card("AD", "ACE"),
+        _card("9C", "9"),
+        _card("KH", "KING"),
+    ])
+    assert total == 21 and not soft
+
+    total, soft = hand_value([_card("AH", "ACE"), _card("9C", "9"), _card("KH", "KING")])
+    assert total == 20 and not soft
+
+
+def test_play_round_smoke(monkeypatch):
+    def fake_init(self, decks: int = 6, session=None) -> None:
+        self.deck_id = "test"
+        self.initial_remaining = 52 * decks
+        self._remaining = self.initial_remaining
+
+    monkeypatch.setattr(DeckClient, "__init__", fake_init)
+
+    sequence = [
+        [_card("10H", "10"), _card("9C", "9")],  # player
+        [_card("7D", "7"), _card("8S", "8")],   # dealer
+        [_card("QC", "QUEEN")],                    # dealer draw (busts)
+    ]
+
+    def fake_draw(self, n: int = 1):
+        self._remaining -= n
+        return sequence.pop(0)
+
+    monkeypatch.setattr(DeckClient, "draw", fake_draw)
+    monkeypatch.setattr(DeckClient, "reshuffle_remaining", lambda self: None)
+    monkeypatch.setattr(blackjack, "prompt_hit_or_stand", lambda: "stand")
+
+    client = DeckClient()
+    player = Player("Tester", bankroll=100, bet=10)
+    stats = {"played": 0, "won": 0, "lost": 0, "push": 0}
+
+    blackjack.play_round(client, player, stats)
+
+    assert player.bankroll == 110
+    assert stats == {"played": 1, "won": 1, "lost": 0, "push": 0}


### PR DESCRIPTION
## Summary
- Implement `DeckClient` for Deck of Cards API with retry logic
- Build Blackjack CLI with hand evaluation, dealer logic, and round play
- Add pytest suite for hand values and round outcomes

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68beb6744ed08325b023581af6b7c58f