### PR TITLE
Add Flask web blackjack game

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import List
+
+from flask import Flask, jsonify, render_template, session
+
+from blackjack import hand_value, should_dealer_draw
+from deck_api import Card, DeckClient
+
+app = Flask(__name__)
+app.secret_key = "dev-key"  # for demonstration
+
+# store deck clients in memory, keyed by deck id
+DECKS: dict[str, DeckClient] = {}
+
+BET_AMOUNT = 10
+START_BANKROLL = 100
+
+
+def _get_deck() -> DeckClient:
+    deck_id = session.get("deck_id")
+    if deck_id and deck_id in DECKS:
+        return DECKS[deck_id]
+    deck = DeckClient()
+    DECKS[deck.deck_id] = deck
+    session["deck_id"] = deck.deck_id
+    return deck
+
+
+def _cards_from_session(key: str) -> List[Card]:
+    return [Card(**c) for c in session.get(key, [])]
+
+
+def _save_cards(key: str, cards: List[Card]) -> None:
+    session[key] = [asdict(c) for c in cards]
+
+
+def _current_state(*, hide_dealer: bool, message: str = ""):
+    player_cards = _cards_from_session("player_hand")
+    dealer_cards = _cards_from_session("dealer_hand")
+
+    p_total, _ = hand_value(player_cards) if player_cards else (0, False)
+    if hide_dealer and dealer_cards:
+        visible_dealer = [dealer_cards[0]]
+        d_total = None
+    else:
+        visible_dealer = dealer_cards
+        d_total, _ = hand_value(dealer_cards) if dealer_cards else (0, False)
+
+    status = "player_turn" if session.get("in_round") else "waiting"
+    return {
+        "player": {"cards": [asdict(c) for c in player_cards], "value": p_total},
+        "dealer": {
+            "cards": [asdict(c) for c in visible_dealer],
+            "value": d_total,
+        },
+        "bankroll": session.get("bankroll", START_BANKROLL),
+        "status": status,
+        "message": message,
+    }
+
+
+@app.route("/")
+def index():
+    # ensure bankroll exists
+    session.setdefault("bankroll", START_BANKROLL)
+    return render_template("index.html")
+
+
+@app.route("/state")
+def state():
+    hide = session.get("in_round", False)
+    return jsonify(_current_state(hide_dealer=hide))
+
+
+@app.route("/start", methods=["POST"])
+def start_round():
+    deck = _get_deck()
+    if deck.remaining < 0.25 * deck.initial_remaining:
+        deck.reshuffle_remaining()
+
+    player = deck.draw(2)
+    dealer = deck.draw(2)
+    _save_cards("player_hand", player)
+    _save_cards("dealer_hand", dealer)
+    session["in_round"] = True
+
+    return jsonify(_current_state(hide_dealer=True))
+
+
+@app.route("/hit", methods=["POST"])
+def hit():
+    if not session.get("in_round"):
+        return jsonify(_current_state(hide_dealer=False))
+    deck = _get_deck()
+    player_cards = _cards_from_session("player_hand")
+    player_cards.extend(deck.draw(1))
+    _save_cards("player_hand", player_cards)
+    total, _ = hand_value(player_cards)
+    if total > 21:
+        session["bankroll"] = session.get("bankroll", START_BANKROLL) - BET_AMOUNT
+        session["in_round"] = False
+        return jsonify(_current_state(hide_dealer=False, message="Bust! You lose."))
+    return jsonify(_current_state(hide_dealer=True))
+
+
+@app.route("/stand", methods=["POST"])
+def stand():
+    if not session.get("in_round"):
+        return jsonify(_current_state(hide_dealer=False))
+    deck = _get_deck()
+    dealer_cards = _cards_from_session("dealer_hand")
+    while should_dealer_draw(dealer_cards):
+        dealer_cards.extend(deck.draw(1))
+    _save_cards("dealer_hand", dealer_cards)
+
+    player_total, _ = hand_value(_cards_from_session("player_hand"))
+    dealer_total, _ = hand_value(dealer_cards)
+
+    bankroll = session.get("bankroll", START_BANKROLL)
+    if dealer_total > 21 or player_total > dealer_total:
+        bankroll += BET_AMOUNT
+        message = "You win!"
+    elif player_total < dealer_total:
+        bankroll -= BET_AMOUNT
+        message = "Dealer wins!"
+    else:
+        message = "Push!"
+    session["bankroll"] = bankroll
+    session["in_round"] = False
+    return jsonify(_current_state(hide_dealer=False, message=message))
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+Flask>=3.0
 requests>=2.31.0
 pytest>=7.0.0

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,61 @@
+async function post(action) {
+    const resp = await fetch('/' + action, {method: 'POST'});
+    return resp.json();
+}
+
+function render(state) {
+    document.getElementById('bankroll-value').textContent = state.bankroll;
+    const playerCards = document.getElementById('player-cards');
+    const dealerCards = document.getElementById('dealer-cards');
+    playerCards.innerHTML = '';
+    dealerCards.innerHTML = '';
+    state.player.cards.forEach(c => {
+        const img = document.createElement('img');
+        img.src = c.image;
+        playerCards.appendChild(img);
+    });
+    state.dealer.cards.forEach(c => {
+        const img = document.createElement('img');
+        img.src = c.image;
+        dealerCards.appendChild(img);
+    });
+    document.getElementById('player-value').textContent = state.player.value || '';
+    document.getElementById('dealer-value').textContent = state.dealer.value ?? '';
+    document.getElementById('message').textContent = state.message || '';
+
+    const hitBtn = document.getElementById('hit-btn');
+    const standBtn = document.getElementById('stand-btn');
+    const dealBtn = document.getElementById('deal-btn');
+    if (state.status === 'player_turn') {
+        hitBtn.disabled = false;
+        standBtn.disabled = false;
+        dealBtn.disabled = true;
+    } else {
+        hitBtn.disabled = true;
+        standBtn.disabled = true;
+        dealBtn.disabled = false;
+    }
+}
+
+document.getElementById('deal-btn').addEventListener('click', async () => {
+    const state = await post('start');
+    render(state);
+});
+
+document.getElementById('hit-btn').addEventListener('click', async () => {
+    const state = await post('hit');
+    render(state);
+});
+
+document.getElementById('stand-btn').addEventListener('click', async () => {
+    const state = await post('stand');
+    render(state);
+});
+
+(async () => {
+    const resp = await fetch('/state');
+    if (resp.ok) {
+        const state = await resp.json();
+        render(state);
+    }
+})();

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,32 @@
+body {
+    background-color: #006400;
+    color: #fff;
+    font-family: Arial, sans-serif;
+    text-align: center;
+}
+
+#game {
+    max-width: 800px;
+    margin: auto;
+    padding: 20px;
+}
+
+.cards img {
+    height: 120px;
+    margin: 5px;
+}
+
+#controls button {
+    margin: 5px;
+    padding: 10px 20px;
+    font-size: 16px;
+}
+
+.hand {
+    margin-bottom: 20px;
+}
+
+#message {
+    font-size: 20px;
+    margin-top: 10px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Blackjack</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <div id="game">
+        <h1>Blackjack</h1>
+        <div id="bankroll">Bankroll: $<span id="bankroll-value"></span></div>
+        <div class="hand">
+            <h2>Dealer (<span id="dealer-value"></span>)</h2>
+            <div id="dealer-cards" class="cards"></div>
+        </div>
+        <div class="hand">
+            <h2>You (<span id="player-value"></span>)</h2>
+            <div id="player-cards" class="cards"></div>
+        </div>
+        <div id="controls">
+            <button id="deal-btn">Deal</button>
+            <button id="hit-btn" disabled>Hit</button>
+            <button id="stand-btn" disabled>Stand</button>
+        </div>
+        <div id="message"></div>
+    </div>
+    <script src="{{ url_for('static', filename='script.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add Flask backend that connects to Deck of Cards API and manages game state, bankroll, and gameplay logic.
- Serve interactive HTML/CSS/JS frontend for playing Blackjack with card images and Hit/Stand controls.
- Include Flask in requirements for minimal deployment.

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`
- `flask --app app routes`


------
https://chatgpt.com/codex/tasks/task_e_68bec5ef49948325ad9fe2badde73023