### PR TITLE
Improve blackjack docs and client UI

### DIFF
--- a/blackjack.py
+++ b/blackjack.py
@@ -26,6 +26,14 @@ class Player:
 
 
 def hand_value(cards: List[Card]) -> Tuple[int, bool]:
+    """Return the Blackjack value for ``cards``.
+
+    The total is calculated with standard Blackjack rules where face cards
+    count as 10 and aces can count as 1 or 11.  The returned tuple contains
+    the numeric total and a boolean indicating whether the hand is *soft*
+    (i.e. at least one ace is counted as 11).
+    """
+
     total = 0
     aces = 0
     for c in cards:
@@ -37,20 +45,24 @@ def hand_value(cards: List[Card]) -> Tuple[int, bool]:
             aces += 1
         else:
             total += int(v)
+
     while total > 21 and aces:
         total -= 10
         aces -= 1
+
     is_soft = aces > 0 and total < 21
     return total, is_soft
 
 
 def should_dealer_draw(cards: List[Card]) -> bool:
-    total, is_soft = hand_value(cards)
-    if total < 17:
-        return True
-    if total == 17 and is_soft:
-        return False
-    return False
+    """Return ``True`` if the dealer should draw another card.
+
+    By default the dealer stands on all 17s, including soft 17.  The logic is
+    therefore simply a check that the total is below 17.
+    """
+
+    total, _ = hand_value(cards)
+    return total < 17
 
 
 def prompt_hit_or_stand() -> str:

--- a/static/script.js
+++ b/static/script.js
@@ -1,6 +1,13 @@
 async function post(action) {
-    const resp = await fetch('/' + action, {method: 'POST'});
-    return resp.json();
+    try {
+        const resp = await fetch('/' + action, { method: 'POST' });
+        if (resp.ok) {
+            return await resp.json();
+        }
+    } catch (err) {
+        console.error(err);
+    }
+    return { message: 'Network error', player: { cards: [] }, dealer: { cards: [] } };
 }
 
 function render(state) {
@@ -12,11 +19,13 @@ function render(state) {
     state.player.cards.forEach(c => {
         const img = document.createElement('img');
         img.src = c.image;
+        img.alt = c.code;
         playerCards.appendChild(img);
     });
     state.dealer.cards.forEach(c => {
         const img = document.createElement('img');
         img.src = c.image;
+        img.alt = c.code;
         dealerCards.appendChild(img);
     });
     document.getElementById('player-value').textContent = state.player.value || '';

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Blackjack</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>


### PR DESCRIPTION
## Summary
- Document and simplify hand evaluation and dealer-draw logic
- Add fetch error handling and alt text for card images on the client
- Make HTML page mobile-friendly with a viewport meta tag

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bec74143708325bfbb9beb55ae6540